### PR TITLE
feature: add endpoints for Curriculum Vitae management

### DIFF
--- a/backend/documents_service/main.py
+++ b/backend/documents_service/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from starlette.middleware.cors import CORSMiddleware
 
-from .routes import documents
+from .routes import documents, cv
 from .database import Base, engine
 from .models.job_postings import JobPostings
 
@@ -16,5 +16,6 @@ app.add_middleware(
 )
 
 app.include_router(documents.router)
+app.include_router(cv.router)
 
 Base.metadata.create_all(bind=engine)

--- a/backend/documents_service/models/curriculum_vitaes.py
+++ b/backend/documents_service/models/curriculum_vitaes.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime, UTC
+from ..database import Base
+import uuid
+
+class CurriculumVitaes(Base):
+    __tablename__ = 'curriculum_vitaes'
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    applicant_id = Column(UUID(as_uuid=True), nullable=False)
+    content = Column(String, nullable=False)
+    upload_date = Column(DateTime, default=datetime.now(UTC), nullable=False)

--- a/backend/documents_service/models/job_postings.py
+++ b/backend/documents_service/models/job_postings.py
@@ -13,7 +13,7 @@ class JobPostings(Base):
     __tablename__ = 'job_postings'
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    recruiter_id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    recruiter_id = Column(UUID(as_uuid=True), nullable=False)
     title = Column(String, nullable=False)
     years_of_experience = Column(Integer, nullable=False)
     category = Column(Enum(JobCategory), nullable=False)

--- a/backend/documents_service/routes/cv.py
+++ b/backend/documents_service/routes/cv.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, Depends, Form, File, UploadFile, HTTPException
+from sqlalchemy.orm import Session
+from starlette import status
+from typing import Annotated
+
+from ..database import SessionLocal
+from ..services import cv
+from ..models.curriculum_vitaes import CurriculumVitaes
+
+router = APIRouter(
+    prefix='/cv',
+    tags=['cv']
+)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+db_dependency = Annotated[Session, Depends(get_db)]
+
+@router.post(
+    path='/upload',
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_cv(
+        db: db_dependency,
+        applicant_id=Form(...),
+        file: UploadFile = File(...)
+):
+    cv_content = await cv.extract_text_from_cv(file)
+
+    new_cv = CurriculumVitaes(
+        applicant_id=applicant_id,
+        content=cv_content
+    )
+
+    db.add(new_cv)
+    db.commit()
+    db.refresh(new_cv)
+
+    return {'response': new_cv}

--- a/backend/documents_service/routes/documents.py
+++ b/backend/documents_service/routes/documents.py
@@ -23,22 +23,18 @@ def get_db():
 
 db_dependency = Annotated[Session, Depends(get_db)]
 
-@router.get('/', status_code=status.HTTP_200_OK)
-def get_documents():
-    return {'message': 'documents endpoint'}
-
 @router.post('/create-job-posting', status_code=status.HTTP_201_CREATED)
-async def create_posting(db: db_dependency,
-                         recruiter_id: UUID = Form(...),
-                         title: str = Form(...),
-                         years_of_experience: int = Form(...),
-                         category: JobCategory = Form(...),
-                         company_name: str = Form(...),
-                         requirements: str = Form(...),
-                         full_description: str = Form(...),
-                         company_image: UploadFile = File(None)
-                         ):
-
+async def create_posting(
+        db: db_dependency,
+        recruiter_id: UUID = Form(...),
+        title: str = Form(...),
+        years_of_experience: int = Form(...),
+        category: JobCategory = Form(...),
+        company_name: str = Form(...),
+        requirements: str = Form(...),
+        full_description: str = Form(...),
+        company_image: UploadFile = File(None)
+):
     try:
         if company_image is not None:
             blob_url = upload_blob(company_image)

--- a/backend/documents_service/routes/documents.py
+++ b/backend/documents_service/routes/documents.py
@@ -1,11 +1,12 @@
-from fastapi import APIRouter, Depends, Form, File, UploadFile
-from typing import Annotated
+from fastapi import APIRouter, Depends, Form, File, UploadFile, HTTPException
+from typing import Annotated, List
 from sqlalchemy.orm import Session
 from starlette import status
 from uuid import UUID
 
 from ..database import SessionLocal
 from ..models.job_postings import JobPostings, JobCategory
+from ..schemas.job_postings import JobPostingResponse
 from ..services.blob_storage import upload_blob
 
 router = APIRouter(
@@ -56,3 +57,37 @@ async def create_posting(db: db_dependency,
     db.refresh(new_job_posting)
 
     return new_job_posting
+
+@router.get(
+    path='/job-postings',
+    response_model=List[JobPostingResponse],
+    status_code=status.HTTP_200_OK
+)
+def get_jobs(db: db_dependency):
+    return db.query(JobPostings).all()
+
+@router.get(
+    path='/job-postings/{job_posting_id}',
+    response_model=List[JobPostingResponse],
+    status_code=status.HTTP_200_OK
+)
+def get_job(db: db_dependency, job_posting_id: UUID):
+    postings = db.query(JobPostings).filter(JobPostings.id == job_posting_id).all()
+
+    if not postings:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job posting not found")
+
+    return postings
+
+@router.get(
+    path='/job-postings/recruiter/{recruiter_id}',
+    response_model=List[JobPostingResponse],
+    status_code=status.HTTP_200_OK
+)
+def get_jobs_by_recruiter_id(db: db_dependency, recruiter_id: UUID):
+    postings = db.query(JobPostings).filter(JobPostings.recruiter_id == recruiter_id).all()
+
+    if not postings:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="None job postings were found for this recruiter")
+
+    return postings

--- a/backend/documents_service/schemas/job_postings.py
+++ b/backend/documents_service/schemas/job_postings.py
@@ -16,3 +16,17 @@ class CreateJobPostingRequest(BaseModel):
     company_image: str
     requirements: str
     full_description: str
+
+class JobPostingResponse(BaseModel):
+    id: UUID
+    recruiter_id: UUID
+    title: str
+    years_of_experience: int
+    category: JobCategory
+    company_name: str
+    company_image: str
+    requirements: str
+    full_description: str
+
+    class Config:
+        from_attributes = True

--- a/backend/documents_service/services/cv.py
+++ b/backend/documents_service/services/cv.py
@@ -1,0 +1,40 @@
+import os.path
+
+from fastapi import HTTPException, UploadFile
+from starlette import status
+from fastapi import UploadFile
+import fitz
+import docx2txt
+
+async def extract_text_from_cv(file: UploadFile):
+    file_ext = await get_file_extension(file)
+    content = await file.read()
+
+    if file_ext == 'txt':
+        return content.decode('utf-8')
+
+    elif file_ext == 'pdf':
+        file = fitz.open(stream=content, filetype='pdf')
+        return '\n'.join(page.get_text() for page in file)
+
+    else: # file_ext in ['doc', 'docx']
+        temp_path = f'temp.{file_ext}'
+
+        try:
+            with open(temp_path, 'wb') as f:
+                f.write(content)
+            return docx2txt.process(temp_path)
+        finally:
+            if os.path.exists(temp_path):
+                os.remove(temp_path)
+
+async def get_file_extension(file: UploadFile) -> str:
+    file_ext = file.filename.lower().split('.')[-1]
+
+    if file_ext in ['pdf', 'txt', 'doc', 'docx']:
+        return file_ext
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail='File type not supported.'
+        )


### PR DESCRIPTION
This pull request introduces significant updates to the `documents_service` backend, focusing on expanding functionality for handling curriculum vitae (CV) uploads.

### CV Management Enhancements:
* **Added `CurriculumVitaes` model**: Created a new database model to store CVs.
* **Created `cv` routes**: Added a new router for CV-related endpoints.
* **Implemented CV text extraction service**: Developed a utility to extract text from CV files in various formats (`pdf`, `doc`, `docx`, `txt`).
### Job Postings Enhancements:
* **Improved `JobPostings` model**: Updated the `recruiter_id` field to be non-primary and mandatory, ensuring better data integrity.
* **Added new job postings routes**: Introduced endpoints to retrieve job postings by ID, recruiter ID, and all postings.
* **Created `JobPostingResponse` schema**: Defined a response model to structure job postings data returned by new endpoints.